### PR TITLE
Honor `login_fail_exit` when reconnecting

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -177,6 +177,9 @@ func (svr *Service) keepControllerWorking() {
 			xl.Info("try to reconnect to server...")
 			conn, session, err := svr.login()
 			if err != nil {
+				if svr.cfg.LoginFailExit {
+					return err
+				}
 				xl.Warn("reconnect to server error: %v", err)
 				time.Sleep(delayTime)
 


### PR DESCRIPTION
`login_fail_exit` is honored when initially connecting, but currently has no effect when reconnecting.

This adds a check after attempting to reconnect, so that a failure there is treated the same as a failure during the initial connection, if `login_fail_exit` is set to true.